### PR TITLE
Update UI for all pages relating to Create Room

### DIFF
--- a/src/components/pages/Create.jsx
+++ b/src/components/pages/Create.jsx
@@ -49,10 +49,6 @@ class Create extends Component {
         })
     }
 
-    copyToClipboard = (event) => {
-        
-    }
-
     render() {
         const {authenticated,pagetype,gameId} = this.state;
         if (authenticated == 'N/A') 

--- a/src/components/pages/Create.jsx
+++ b/src/components/pages/Create.jsx
@@ -2,6 +2,12 @@ import React, {Component} from 'react';
 import {Link,Redirect} from 'react-router-dom';
 import {db,fire,auth,firestore} from '../../firebase.js';
 import Config from '../quiz/create/Config.jsx';
+import {Helmet} from "react-helmet";
+import {CopyToClipboard} from 'react-copy-to-clipboard';
+
+import {Text} from 'react-native';
+import * as styles from '../styles/CreateStyle.jsx';
+import Button from "@material-ui/core/Button";
 
 class Create extends Component {
 
@@ -43,23 +49,46 @@ class Create extends Component {
         })
     }
 
+    copyToClipboard = (event) => {
+        
+    }
+
     render() {
         const {authenticated,pagetype,gameId} = this.state;
         if (authenticated == 'N/A') 
             return <Redirect to="/" />   
         return (
             <div className="app-page create-page">
+                <Helmet><title>Create Room</title></Helmet>
                 {pagetype === 'not-created' &&
                    <Config updatePageType={this.updatePageType.bind(this)}/>
                 }
 
                 {pagetype === 'created' && (
                     <div>
-                        <span>Created game PIN: </span>
-                        {' '}
-                        <span className="dynamic-text">{gameId}</span>
-                        {' '}
-                        <Link to="/host">Copy this ID and use it host the game</Link>
+                        <body style={styles.body}>
+                            <div style={styles.box}>
+                                <Text style={styles.h1}>Successfully created room!</Text>
+                            </div>
+                            <br/>
+
+                            <label style={styles.gamePIN}>Game PIN: </label>
+                            <span className="dynamic-text">{gameId}</span>
+
+                            <CopyToClipboard text={gameId}
+                                onCopy={() => alert('Copied to clipboard!')}
+                            >
+                                <button style={styles.copyButtonStyle}>Copy</button>
+                            </CopyToClipboard>
+                            <br/>
+
+                            <p>Click the Copy button above to copy the Game PIN to your clipboard.</p>
+                            <p>Then, click the button below to host the game!</p>
+                            <Link to='/host' style={{textDecoration: 'none'}}>
+                                <Button style={styles.buttonStyle} to="/host">Host</Button>
+                            </Link>
+                            
+                        </body>
                     </div>
                 )}
             </div>

--- a/src/components/quiz/Instructions.jsx
+++ b/src/components/quiz/Instructions.jsx
@@ -87,6 +87,18 @@ class Instructions extends Component {
                             </div>
                         }
 
+                        {info == 'create' &&
+                        
+                            <div>
+                                <h1>You are on the Create Room page.</h1>
+                                <p>Here, you can customize your game settings.</p>
+                                <br/>
+                                <h3>Rounds</h3>
+                                <p>You can choose to play anywhere from 1 to 7 rounds.</p>
+                                <h3>Symbols</h3>
+                                <p>You can choose how many symbols you want to track during the game.</p>
+                            </div>
+                        }
                     </div>
                 <div> <Button style={styles.buttonStyle} onClick={this.props.closeInstructions}> Close </Button> </div>
 

--- a/src/components/quiz/create/Config.jsx
+++ b/src/components/quiz/create/Config.jsx
@@ -7,7 +7,11 @@ import NumericInput from 'react-numeric-input';
 import FormControl from "@material-ui/core/FormControl";
 import TextField from "@material-ui/core/TextField";
 
-//TODO Add UI
+import Instructions from "../Instructions";
+import {Text} from 'react-native';
+import * as styles from '../../styles/CreateStyle.jsx';
+import Button from "@material-ui/core/Button";
+
 class Config extends React.Component {
 
     constructor(props) {
@@ -15,6 +19,7 @@ class Config extends React.Component {
         this.state = {
             numSymbols: 1,
             numRounds: 1,
+            displayInstructions: false,
         };
         this.createRoom = this.createRoom.bind(this);
     }
@@ -33,17 +38,49 @@ class Config extends React.Component {
         console.log(this.props.roomId);
     }
 
+    toggleInstructions() {
+        this.setState({
+            displayInstructions: !this.state.displayInstructions
+        })
+    }
+
     render() {
-        const {numSymbols,numRounds} = this.state;
+        const {numSymbols,numRounds,displayInstructions} = this.state;
         return (
             <div>
-                <p> Set number of symbols </p>
-                <NumericInput type='number' name="numSymbols" step={1} value={this.state.numSymbols} min={1} max={7}
+                <body style={styles.body}>
+
+                    {displayInstructions &&
+                    <Instructions
+                        info='create'
+                        closeInstructions={this.toggleInstructions.bind(this)}
+                    />
+
+                    }
+
+                    <div style={styles.box}>
+                        <Text style={styles.h1}> Create Game Room </Text>
+                    </div>
+                    
+                    <Button style={styles.buttonStyle} onClick={this.toggleInstructions.bind(this)}>
+                        Instructions
+                    </Button>
+         
+                    <br/><br/><br/>
+                    <label> Set number of symbols </label>
+                    <NumericInput style={styles.numericinput} type='number' name="numSymbols" step={1} value={this.state.numSymbols} min={1} max={7}
                        onChange={this.handleChange.bind(this,'numSymbols')}/>
-                <p> Set number of rounds </p>
-                <NumericInput type='number' name="numRounds" step={1} value={this.state.numRounds} min={1} max={7}
+                    <br/><br/>
+
+                    <label> Set number of rounds </label>
+                    <NumericInput type='number' name="numRounds" step={1} value={this.state.numRounds} min={1} max={7}
                        onChange={this.handleChange.bind(this,'numRounds')}/>
-                <button onClick={() => this.createRoom()}> Create room </button>
+
+                    <br/><br/><br/>
+                    <Button style={styles.buttonStyle} onClick={() => this.createRoom()}> 
+                        Create room
+                    </Button>
+                </body>
             </div>
         );
     }

--- a/src/components/quiz/create/Config.jsx
+++ b/src/components/quiz/create/Config.jsx
@@ -35,7 +35,6 @@ class Config extends React.Component {
         const {numSymbols,numRounds} = this.state;
         var roomID = setUpRoom(numSymbols,numRounds,'');
         this.props.updatePageType('created',roomID);
-        console.log(this.props.roomId);
     }
 
     toggleInstructions() {

--- a/src/components/styles/CreateStyle.jsx
+++ b/src/components/styles/CreateStyle.jsx
@@ -1,0 +1,65 @@
+import Background from "../assets/background.jpg";
+
+export const body = {
+    fontFamily: "Calibri",
+    textAlign: "center",
+    backgroundImage: "url("+Background+")",
+    minHeight: '100vh',
+    minWidth: '100%',
+}
+
+export const box = {
+    background: 'white',
+    borderRadius: '10px',
+    padding: '10px',
+    width: '60%',
+    fontSize: '30px',
+    opacity: '0.7',
+    margin: 'auto',
+    shadow: '10px 10px 40px 7px rbga(0,0,0,0.5)',
+}
+
+export const buttonStyle = {
+    background: 'linear-gradient(45deg,#FE6B8B 30%, #FF8E53 90%)',
+    borderRadius: 3,
+    border: 0,
+    color: 'white',
+    padding: '13px',
+    boxShadow: '0 3px 5px 2px rgba(255,105,135,.3)',
+    align: 'center',
+    width: '10rem',
+    marginTop: '1rem',
+    margin: '1rem 1rem 1rem 1rem'
+}
+
+export const copyButtonStyle = {
+    background: 'linear-gradient(45deg,#FE6B8B 30%, #FF8E53 90%)',
+    borderRadius: 3,
+    border: 0,
+    color: 'white',
+    padding: '5px',
+    boxShadow: '0 3px 5px 2px rgba(255,105,135,.3)',
+    align: 'center',
+    width: '3rem',
+    marginTop: '1rem',
+    margin: '1rem 1rem 1rem 1rem'
+}
+
+export const gamePIN = {
+    fontWeight: 'bold',
+    fontSize: '20px'
+}
+
+export const numericinput = {
+    borderRadius: '10px',
+    padding: '10px',
+    width: '10%',
+    fontSize: '10px',
+    margin: 'auto',
+    color: 'red'
+}
+
+export const h1 = {
+    fontWeight: 'bold',
+    fontSize: '30px',
+}


### PR DESCRIPTION
The following page appears upon entering the page:
<img width="1225" alt="Screen Shot 2020-07-31 at 1 39 40 PM" src="https://user-images.githubusercontent.com/32241907/89062417-671dfc80-d334-11ea-9226-adb4f90c1f32.png">

Once clicking info, this appears:
<img width="1223" alt="Screen Shot 2020-07-31 at 1 40 44 PM" src="https://user-images.githubusercontent.com/32241907/89062421-68e7c000-d334-11ea-8145-ffc3a383337c.png">

After clicking create room, this appears:
<img width="1224" alt="Screen Shot 2020-07-31 at 1 41 13 PM" src="https://user-images.githubusercontent.com/32241907/89062424-69805680-d334-11ea-9bb9-22c754fd60e2.png">

Add instructions for create, style config + create.
